### PR TITLE
Assertion is fixed and dropout layer is added.

### DIFF
--- a/minGRU_pytorch/minLM.py
+++ b/minGRU_pytorch/minLM.py
@@ -100,7 +100,7 @@ class minLM(Module):
             # conv
 
             if exists(conv):
-                assert not exists(prev_hiddens), 'caching not supported for conv version'
+                assert len(list(prev_hiddens)) == 0, 'caching not supported for conv version'
                 x = conv(x) + x
 
             # min gru


### PR DESCRIPTION
The default function in line `prev_hiddens = iter(default(prev_hiddens, []))` returns an empty list even if prev_hiddens is None. Thus, an iterator object is always returned. Even if the prev_hiddens wasn't passed to the forward method, in the main for loop there is an object passed. Also I added a dropout layer as in the paper they mentioned that it was present. 

Resolves #15.